### PR TITLE
Adding description for Scheduling Pro public APIs

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -58,7 +58,8 @@ export class ApiService {
         "tenant-task-management-v2": "Task Management Data, Tasks endpoints.",
         "tenant-telecom": "Calls endpoints.",
         "tenant-telecom-v2": "Calls endpoint.",
-        "tenant-telecom-v3": "Calls endpoint."
+        "tenant-telecom-v3": "Calls endpoint.",
+        "tenant-scheduling-pro-v2": "Schedulers, Scheduler Sessions endpoints."
       }
 
     private readonly betaApis: Set<string> = new Set<string>(["tenant-reporting-v2"]);

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -53,13 +53,13 @@ export class ApiService {
         "tenant-pricebook-v2": "Categories, Discounts and Fees, Equipment, Materials, Pricebook Bulk Operations, Pricebook Images, Services endpoints.",
         "tenant-reporting-v2": "Dynamic Value Sets, Report Categories, Reports within the category endpoints.",
         "tenant-salestech-v2": "Estimates endpoint.",
+        "tenant-scheduling-pro-v2": "Schedulers, Scheduler Sessions endpoints.",
         "tenant-service-agreements-v2": "Service Agreements endpoints.",
         "tenant-settings-v2": "Business Units, Employees, Tag Types, Technicians, User Roles endpoints.",
         "tenant-task-management-v2": "Task Management Data, Tasks endpoints.",
         "tenant-telecom": "Calls endpoints.",
         "tenant-telecom-v2": "Calls endpoint.",
-        "tenant-telecom-v3": "Calls endpoint.",
-        "tenant-scheduling-pro-v2": "Schedulers, Scheduler Sessions endpoints."
+        "tenant-telecom-v3": "Calls endpoint."
       }
 
     private readonly betaApis: Set<string> = new Set<string>(["tenant-reporting-v2"]);


### PR DESCRIPTION
Adding description for Scheduling Pro public APIs. As of now the description is empty:

![image-20241001-141513](https://github.com/user-attachments/assets/2f558db6-530f-4e20-aa79-780e2a6604bb)
